### PR TITLE
Expand multi-objective metrics for optimizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,11 @@
                     dexterity: evaluation.dexterity,
                     stiffness: evaluation.stiffness,
                     torque: evaluation.torque,
+                    speedDemand: evaluation.speedDemand,
+                    loadBalance: evaluation.loadBalance,
+                    isotropy: evaluation.isotropy,
+                    limitMargin: evaluation.limitMargin,
+                    fatigue: evaluation.fatigue,
                 },
                 layout: {
                     base_anchors: evaluation.layout.baseAnchors,
@@ -305,6 +310,7 @@
                     servo_range: evaluation.layout.servoRangeRad.map((rad) => rad * 180 / Math.PI),
                     home_height: evaluation.layout.homeHeight,
                 },
+                workspace_stats: evaluation.workspace?.stats,
             }, null, 2);
         }
 

--- a/math.js
+++ b/math.js
@@ -206,6 +206,21 @@ export function sum(values) {
   return values.reduce((acc, v) => acc + v, 0);
 }
 
+export function variance(values) {
+  if (!values.length) return 0;
+  const mean = average(values);
+  const squared = values.map((value) => {
+    const diff = value - mean;
+    return diff * diff;
+  });
+  return average(squared);
+}
+
+export function standardDeviation(values) {
+  if (!values.length) return 0;
+  return Math.sqrt(variance(values));
+}
+
 export function squaredDistance(a, b) {
   const dx = a[0] - b[0];
   const dy = a[1] - b[1];


### PR DESCRIPTION
## Summary
- add statistical helpers to support new workspace aggregation metrics
- extend workspace evaluation to collect isotropy, stiffness, load balancing, and limit usage statistics that drive multi-objective scoring
- update the optimizer and UI to expose torque, speed demand, fatigue, and constraint margins in the Pareto analysis output

## Testing
- node --input-type=module -e "import('./optimizer.js').then(()=>console.log('loaded')).catch(err=>{console.error(err); process.exit(1);});"

------
https://chatgpt.com/codex/tasks/task_b_68cf73d6e5248331b8ac9ff7e6007f62