### PR TITLE
Limit workspace sampling memory

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,8 @@
                     home_height: evaluation.layout.homeHeight,
                 },
                 workspace_stats: evaluation.workspace?.stats,
+                workspace_counts: evaluation.workspace?.counts,
+                workspace_samples: evaluation.workspace?.samples,
             }, null, 2);
         }
 


### PR DESCRIPTION
## Summary
- limit workspace sampling to aggregated metrics and reservoir-sampled metadata to keep memory usage bounded
- expose workspace summary counts/limits and include them in the exported JSON payload

## Testing
- node --input-type=module -e "import('./workspace.js').then(() => console.log('workspace loaded')).catch((err) => { console.error(err); process.exit(1); });"


------
https://chatgpt.com/codex/tasks/task_b_68cf79ad62b48331ae0c5cb3aaaaf5a8