### PR TITLE
Handle nested requirements schema input

### DIFF
--- a/Additional_Repo_Stuff/examples/Sample_Requirements.json
+++ b/Additional_Repo_Stuff/examples/Sample_Requirements.json
@@ -1,16 +1,24 @@
 {
-  "mass_kg": 2.5,
-  "cycle_mm": 30,
-  "frequency_hz": 2.0,
-  "cycle_axis": "z",
-  "x_range_mm": [-40, 40],
-  "y_range_mm": [-40, 40],
-  "z_range_mm": [-20, 40],
-  "rx_range_deg": [-12, 12],
-  "ry_range_deg": [-12, 12],
-  "rz_range_deg": [-8, 8],
-  "ball_joint_max_deg": 52,
-  "servo_travel_bounds_deg": [-120, 120],
-  "rod_length_bounds_mm": [180, 380],
-  "horn_length_bounds_mm": [40, 110]
+  "payload": {
+    "mass_kg": 2.5,
+    "cycle_mm": 30,
+    "frequency_hz": 2.0,
+    "cycle_axis": "z"
+  },
+  "workspace": {
+    "x_range_mm": [-40, 40],
+    "y_range_mm": [-40, 40],
+    "z_range_mm": [-20, 40]
+  },
+  "rotations": {
+    "rx_range_deg": [-12, 12],
+    "ry_range_deg": [-12, 12],
+    "rz_range_deg": [-8, 8]
+  },
+  "constraints": {
+    "ball_joint_max_deg": 52,
+    "servo_travel_bounds_deg": [-120, 120],
+    "rod_length_bounds_mm": [180, 380],
+    "horn_length_bounds_mm": [40, 110]
+  }
 }

--- a/requirements.js
+++ b/requirements.js
@@ -1,16 +1,3 @@
-const REQUIRED_FIELDS = [
-  'mass_kg',
-  'cycle_mm',
-  'frequency_hz',
-  'cycle_axis',
-  'x_range_mm',
-  'y_range_mm',
-  'z_range_mm',
-  'rx_range_deg',
-  'ry_range_deg',
-  'rz_range_deg',
-];
-
 const DEFAULTS = {
   ball_joint_max_deg: 45,
   servo_travel_bounds_deg: [-120, 120],
@@ -18,11 +5,27 @@ const DEFAULTS = {
   horn_length_bounds_mm: [30, 110],
 };
 
-function validateRange(range, name) {
-  if (!Array.isArray(range) || range.length !== 2) {
-    throw new Error(`${name} must be an array with [min, max] values.`);
+function normalizeRangeInput(range) {
+  if (Array.isArray(range)) {
+    return range;
   }
-  const [min, max] = range;
+  if (range && typeof range === 'object') {
+    if ('min' in range && 'max' in range) {
+      return [range.min, range.max];
+    }
+    if ('from' in range && 'to' in range) {
+      return [range.from, range.to];
+    }
+  }
+  return null;
+}
+
+function validateRange(range, name) {
+  const candidate = normalizeRangeInput(range);
+  if (!candidate || candidate.length !== 2) {
+    throw new Error(`${name} must define min/max values.`);
+  }
+  const [min, max] = candidate;
   if (!Number.isFinite(min) || !Number.isFinite(max) || max < min) {
     throw new Error(`${name} must contain numeric min/max values with max >= min.`);
   }
@@ -36,6 +39,163 @@ function deriveStep(min, max, fallback) {
   return step > 0 ? step : fallback;
 }
 
+function ensureCycleAxis(value) {
+  if (typeof value !== 'string') {
+    throw new Error('cycle_axis must be a string.');
+  }
+  const axis = value.toLowerCase();
+  if (!['x', 'y', 'z'].includes(axis)) {
+    throw new Error('cycle_axis must be one of "x", "y", or "z".');
+  }
+  return axis;
+}
+
+function buildWorkspaceRanges(source, translationStep, rotationStep) {
+  const xRange = validateRange(source.x_range_mm, 'x_range_mm');
+  const yRange = validateRange(source.y_range_mm, 'y_range_mm');
+  const zRange = validateRange(source.z_range_mm, 'z_range_mm');
+  const rxRange = validateRange(source.rx_range_deg, 'rx_range_deg');
+  const ryRange = validateRange(source.ry_range_deg, 'ry_range_deg');
+  const rzRange = validateRange(source.rz_range_deg, 'rz_range_deg');
+
+  return {
+    x: { min: xRange.min, max: xRange.max, step: deriveStep(xRange.min, xRange.max, translationStep) },
+    y: { min: yRange.min, max: yRange.max, step: deriveStep(yRange.min, yRange.max, translationStep) },
+    z: { min: zRange.min, max: zRange.max, step: deriveStep(zRange.min, zRange.max, translationStep) },
+    rx: { min: rxRange.min, max: rxRange.max, step: deriveStep(rxRange.min, rxRange.max, rotationStep) },
+    ry: { min: ryRange.min, max: ryRange.max, step: deriveStep(ryRange.min, ryRange.max, rotationStep) },
+    rz: { min: rzRange.min, max: rzRange.max, step: deriveStep(rzRange.min, rzRange.max, rotationStep) },
+  };
+}
+
+function parseNestedRequirements(data) {
+  const payload = data.payload || {};
+  const workspace = data.workspace || {};
+  const rotations = data.rotations || {};
+  const constraints = data.constraints || {};
+
+  const requiredPayload = ['mass_kg', 'cycle_mm', 'frequency_hz', 'cycle_axis'];
+  const requiredWorkspace = ['x_range_mm', 'y_range_mm', 'z_range_mm'];
+  const requiredRotations = ['rx_range_deg', 'ry_range_deg', 'rz_range_deg'];
+
+  for (const field of requiredPayload) {
+    if (!(field in payload)) {
+      throw new Error(`Requirements missing payload field: ${field}`);
+    }
+  }
+
+  for (const field of requiredWorkspace) {
+    if (!(field in workspace)) {
+      throw new Error(`Requirements missing workspace field: ${field}`);
+    }
+  }
+
+  for (const field of requiredRotations) {
+    if (!(field in rotations)) {
+      throw new Error(`Requirements missing rotations field: ${field}`);
+    }
+  }
+
+  const normalized = {
+    mass_kg: payload.mass_kg,
+    cycle_mm: payload.cycle_mm,
+    frequency_hz: payload.frequency_hz,
+    cycle_axis: ensureCycleAxis(payload.cycle_axis),
+    x_range_mm: normalizeRangeInput(workspace.x_range_mm) || workspace.x_range_mm,
+    y_range_mm: normalizeRangeInput(workspace.y_range_mm) || workspace.y_range_mm,
+    z_range_mm: normalizeRangeInput(workspace.z_range_mm) || workspace.z_range_mm,
+    rx_range_deg: normalizeRangeInput(rotations.rx_range_deg) || rotations.rx_range_deg,
+    ry_range_deg: normalizeRangeInput(rotations.ry_range_deg) || rotations.ry_range_deg,
+    rz_range_deg: normalizeRangeInput(rotations.rz_range_deg) || rotations.rz_range_deg,
+  };
+
+  normalized.ball_joint_max_deg = constraints.ball_joint_max_deg ?? DEFAULTS.ball_joint_max_deg;
+  const rodBounds = normalizeRangeInput(constraints.rod_length_bounds_mm);
+  normalized.rod_length_bounds_mm = rodBounds ? [rodBounds[0], rodBounds[1]] : DEFAULTS.rod_length_bounds_mm.slice();
+  const hornBounds = normalizeRangeInput(constraints.horn_length_bounds_mm);
+  normalized.horn_length_bounds_mm = hornBounds ? [hornBounds[0], hornBounds[1]] : DEFAULTS.horn_length_bounds_mm.slice();
+
+  if (Array.isArray(constraints.servo_travel_bounds_deg)) {
+    normalized.servo_travel_bounds_deg = constraints.servo_travel_bounds_deg.slice();
+  } else if (Number.isFinite(constraints.servo_max_deg)) {
+    const max = Math.abs(constraints.servo_max_deg);
+    normalized.servo_travel_bounds_deg = [-max, max];
+  } else {
+    normalized.servo_travel_bounds_deg = DEFAULTS.servo_travel_bounds_deg.slice();
+  }
+
+  return { normalized };
+}
+
+function parseFlatRequirements(data) {
+  const requiredFields = [
+    'mass_kg',
+    'cycle_mm',
+    'frequency_hz',
+    'cycle_axis',
+    'x_range_mm',
+    'y_range_mm',
+    'z_range_mm',
+    'rx_range_deg',
+    'ry_range_deg',
+    'rz_range_deg',
+  ];
+
+  for (const field of requiredFields) {
+    if (!(field in data)) {
+      throw new Error(`Requirements missing field: ${field}`);
+    }
+  }
+
+  const normalized = { ...data };
+  normalized.cycle_axis = ensureCycleAxis(normalized.cycle_axis);
+
+  const rangeFields = [
+    'x_range_mm',
+    'y_range_mm',
+    'z_range_mm',
+    'rx_range_deg',
+    'ry_range_deg',
+    'rz_range_deg',
+  ];
+  for (const field of rangeFields) {
+    const candidate = normalizeRangeInput(normalized[field]);
+    if (!candidate) {
+      throw new Error(`${field} must define min/max values.`);
+    }
+    normalized[field] = [candidate[0], candidate[1]];
+  }
+
+  if ('rod_length_bounds_mm' in normalized) {
+    const candidate = normalizeRangeInput(normalized.rod_length_bounds_mm);
+    if (candidate) {
+      normalized.rod_length_bounds_mm = [candidate[0], candidate[1]];
+    }
+  }
+
+  if ('horn_length_bounds_mm' in normalized) {
+    const candidate = normalizeRangeInput(normalized.horn_length_bounds_mm);
+    if (candidate) {
+      normalized.horn_length_bounds_mm = [candidate[0], candidate[1]];
+    }
+  }
+
+  if (!('servo_travel_bounds_deg' in normalized) && Number.isFinite(normalized.servo_max_deg)) {
+    const max = Math.abs(normalized.servo_max_deg);
+    normalized.servo_travel_bounds_deg = [-max, max];
+  }
+
+  for (const [key, value] of Object.entries(DEFAULTS)) {
+    if (!(key in normalized) || normalized[key] === undefined) {
+      normalized[key] = Array.isArray(value) ? value.slice() : value;
+    } else if (Array.isArray(normalized[key])) {
+      normalized[key] = normalized[key].slice();
+    }
+  }
+
+  return { normalized };
+}
+
 export function parseRequirements(text) {
   let data;
   try {
@@ -44,37 +204,30 @@ export function parseRequirements(text) {
     throw new Error('Requirements JSON is invalid.');
   }
 
-  for (const field of REQUIRED_FIELDS) {
-    if (!(field in data)) {
-      throw new Error(`Requirements missing field: ${field}`);
-    }
+  if (!data || typeof data !== 'object') {
+    throw new Error('Requirements must be a JSON object.');
   }
 
-  const normalized = { ...data };
-  for (const [key, value] of Object.entries(DEFAULTS)) {
-    if (!(key in normalized)) {
-      normalized[key] = Array.isArray(value) ? value.slice() : value;
-    }
-  }
+  const usesNested = 'payload' in data || 'workspace' in data || 'rotations' in data || 'constraints' in data;
+  const { normalized } = usesNested ? parseNestedRequirements(data) : parseFlatRequirements(data);
 
-  const xRange = validateRange(normalized.x_range_mm, 'x_range_mm');
-  const yRange = validateRange(normalized.y_range_mm, 'y_range_mm');
-  const zRange = validateRange(normalized.z_range_mm, 'z_range_mm');
-  const rxRange = validateRange(normalized.rx_range_deg, 'rx_range_deg');
-  const ryRange = validateRange(normalized.ry_range_deg, 'ry_range_deg');
-  const rzRange = validateRange(normalized.rz_range_deg, 'rz_range_deg');
-
-  const translationStep = 5;
-  const rotationStep = 5;
-
-  const workspace = {
-    x: { min: xRange.min, max: xRange.max, step: deriveStep(xRange.min, xRange.max, translationStep) },
-    y: { min: yRange.min, max: yRange.max, step: deriveStep(yRange.min, yRange.max, translationStep) },
-    z: { min: zRange.min, max: zRange.max, step: deriveStep(zRange.min, zRange.max, translationStep) },
-    rx: { min: rxRange.min, max: rxRange.max, step: deriveStep(rxRange.min, rxRange.max, rotationStep) },
-    ry: { min: ryRange.min, max: ryRange.max, step: deriveStep(ryRange.min, ryRange.max, rotationStep) },
-    rz: { min: rzRange.min, max: rzRange.max, step: deriveStep(rzRange.min, rzRange.max, rotationStep) },
+  const workspaceSource = {
+    x_range_mm: normalized.x_range_mm,
+    y_range_mm: normalized.y_range_mm,
+    z_range_mm: normalized.z_range_mm,
+    rx_range_deg: normalized.rx_range_deg,
+    ry_range_deg: normalized.ry_range_deg,
+    rz_range_deg: normalized.rz_range_deg,
   };
+
+  const workspace = buildWorkspaceRanges(workspaceSource, 5, 5);
+
+  normalized.x_range_mm = [workspace.x.min, workspace.x.max];
+  normalized.y_range_mm = [workspace.y.min, workspace.y.max];
+  normalized.z_range_mm = [workspace.z.min, workspace.z.max];
+  normalized.rx_range_deg = [workspace.rx.min, workspace.rx.max];
+  normalized.ry_range_deg = [workspace.ry.min, workspace.ry.max];
+  normalized.rz_range_deg = [workspace.rz.min, workspace.rz.max];
 
   return { normalized, workspace };
 }


### PR DESCRIPTION
## Summary
- extend requirements parsing to accept the nested schema layout, range objects, and servo max bounds while normalizing values for the optimizer
- reuse the workspace range builder for both formats so default steps and constraint defaults remain consistent
- update the bundled sample requirements JSON to match the documented v2 schema structure

## Testing
- node --input-type=module <<'NODE'\nimport { parseRequirements } from './requirements.js';\nimport fs from 'fs/promises';\nconst text = await fs.readFile('./Additional_Repo_Stuff/examples/Sample_Requirements.json', 'utf8');\nconst result = parseRequirements(text);\nconsole.log(JSON.stringify(result, null, 2));\nNODE
- node --input-type=module <<'NODE'\nimport { parseRequirements } from './requirements.js';\nconst flat = JSON.stringify({\n  mass_kg: 1,\n  cycle_mm: 10,\n  frequency_hz: 1,\n  cycle_axis: 'X',\n  x_range_mm: [-10, 10],\n  y_range_mm: [-10, 10],\n  z_range_mm: [-10, 10],\n  rx_range_deg: [-5, 5],\n  ry_range_deg: [-5, 5],\n  rz_range_deg: [-5, 5],\n  servo_max_deg: 90,\n});\nconsole.log(parseRequirements(flat));\nNODE

------
https://chatgpt.com/codex/tasks/task_b_68cf8245da488331a3af1bba3121a94f